### PR TITLE
Docs: Fix Url property in menu

### DIFF
--- a/docs/layouts/partials/menu.html
+++ b/docs/layouts/partials/menu.html
@@ -16,12 +16,12 @@
             </a>
                 <ul class="sub{{if $currentNode.HasMenuCurrent "main" . }} open{{end}}">
                     {{ range .Children }}
-                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.URL}}">{{ .Name }}</a> </li>
+                    <li{{if $currentNode.IsMenuCurrent "main" . }} class="active"{{end}}><a href="{{.Url}}">{{ .Name }}</a> </li>
                     {{ end }}
                 </ul>
               {{else}}
                 <li>
-                <a class="" href="{{.URL}}">
+                <a class="" href="{{.Url}}">
                     {{ .Pre }}
                     <!--<i class="icon_house_alt"></i>-->
                     <span>{{ .Name }}</span>


### PR DESCRIPTION
The current docs don't build under Hugo v0.13. This is a simple fix that matches the property to what is detailed in the menu documentation page.

Specific error this fixes:
```
executing "partials/menu.html" at <.URL>: URL is not a field of struct type *hugolib.MenuEntry in partials/menu.html
```

I've only tested this in the v0.13 release version of Hugo, but I didn't see any breaking changes in master to change `Url` to `URL`.